### PR TITLE
Support variable substitution in TableNode instances

### DIFF
--- a/src/BehatVariablesArgumentTransformer.php
+++ b/src/BehatVariablesArgumentTransformer.php
@@ -34,9 +34,16 @@ class BehatVariablesArgumentTransformer implements ArgumentTransformer {
 	 *
 	 */
 	public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue) {
-		return
-			(($argumentValue instanceof PyStringNode || is_scalar($argumentValue) || $argumentValue instanceof TableNode) &&
-			preg_match_all(self::SLOT_NAME_REGEX, serialize($argumentValue), $this->matches, PREG_SET_ORDER));
+	    // Check if we got a supported data type.
+	    if (($argumentValue instanceof PyStringNode || is_scalar($argumentValue) || $argumentValue instanceof TableNode)) {
+            // Check if there's a valid token in the data.
+            try {
+                return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
+            } finally {
+                // Failure means we can't use the value.
+            }
+        }
+	    return FALSE;
 	}
 
 	/**

--- a/src/BehatVariablesArgumentTransformer.php
+++ b/src/BehatVariablesArgumentTransformer.php
@@ -34,14 +34,13 @@ class BehatVariablesArgumentTransformer implements ArgumentTransformer {
 	 *
 	 */
 	public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue) {
-		if ($argumentValue instanceof PyStringNode || is_scalar($argumentValue)) {
-			return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
+		// Check if the given argument is supported and if so if it contains tokens.
+		switch (true) {
+		  case is_scalar($argumentValue):
+		  case $argumentValue instanceof PyStringNode:
+		  case $argumentValue instanceof TableNode:
+		     return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
 		}
-
-		if ($argumentValue instanceof TableNode) {
-			return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
-		}
-
 		return false;
 	}
 

--- a/src/BehatVariablesArgumentTransformer.php
+++ b/src/BehatVariablesArgumentTransformer.php
@@ -34,16 +34,15 @@ class BehatVariablesArgumentTransformer implements ArgumentTransformer {
 	 *
 	 */
 	public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue) {
-	    // Check if we got a supported data type.
-	    if (($argumentValue instanceof PyStringNode || is_scalar($argumentValue) || $argumentValue instanceof TableNode)) {
-            // Check if there's a valid token in the data.
-            try {
-                return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
-            } finally {
-                // Failure means we can't use the value.
-            }
-        }
-	    return FALSE;
+		if ($argumentValue instanceof PyStringNode || is_scalar($argumentValue)) {
+			return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
+		}
+
+		if ($argumentValue instanceof TableNode) {
+			return (bool) preg_match_all(self::SLOT_NAME_REGEX, (string) $argumentValue, $this->matches, PREG_SET_ORDER);
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/BehatVariablesArgumentTransformer.php
+++ b/src/BehatVariablesArgumentTransformer.php
@@ -6,7 +6,6 @@ use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Transformation\Transformer\ArgumentTransformer;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use Doctrine\DBAL\Schema\Table;
 
 class BehatVariablesArgumentTransformer implements ArgumentTransformer {
 

--- a/src/BehatVariablesArgumentTransformer.php
+++ b/src/BehatVariablesArgumentTransformer.php
@@ -35,7 +35,7 @@ class BehatVariablesArgumentTransformer implements ArgumentTransformer {
 	 */
 	public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue) {
 		return
-			(($argumentValue instanceof PyStringNode || is_scalar($argumentValue || $argumentValue instanceof TableNode)) &&
+			(($argumentValue instanceof PyStringNode || is_scalar($argumentValue) || $argumentValue instanceof TableNode) &&
 			preg_match_all(self::SLOT_NAME_REGEX, serialize($argumentValue), $this->matches, PREG_SET_ORDER));
 	}
 


### PR DESCRIPTION
Currently a consturct like this will fail:
```
    Given a value "{RandomEmail}"
    And save it into "EMAIL"
    Given the following users exist:
      | email     | password         | firstname    | lastname        |
      | <<EMAIL>> | selenium-test-pw | {RandomName} | {RandomSurname} |
```
With the changes made `<<EMAIL>>` should be properly replaced.